### PR TITLE
Resolve:auth-bootstrap-flow

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useAuth } from '@/hooks/useAuth';
+import { Button, Center, Paper, PasswordInput, Stack, Text, TextInput, Title } from '@mantine/core';
+import { useState } from 'react';
+
+const LoginPage = () => {
+  const { login, loginWithGoogle, loading, user, logout } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (submitting) {
+      return;
+    }
+
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      await login(email, password);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Login failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleLogout = async () => {
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      await logout();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Logout failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleGoogleLogin = async () => {
+    if (submitting) {
+      return;
+    }
+
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      await loginWithGoogle();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Google login failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Center h='100vh' px='md'>
+      <Paper w='100%' maw={420} p='xl' withBorder>
+        <Stack gap='md'>
+          <Title order={2}>Login</Title>
+          {user ? (
+            <>
+              <Text size='sm'>Already signed in as {user.email ?? 'unknown user'}.</Text>
+              <Button onClick={handleLogout} loading={submitting} disabled={loading}>
+                Logout
+              </Button>
+            </>
+          ) : (
+            <form onSubmit={handleSubmit}>
+              <Stack gap='sm'>
+                <TextInput
+                  label='Email'
+                  type='email'
+                  value={email}
+                  onChange={(event) => setEmail(event.currentTarget.value)}
+                  required
+                  disabled={loading || submitting}
+                />
+                <PasswordInput
+                  label='Password'
+                  value={password}
+                  onChange={(event) => setPassword(event.currentTarget.value)}
+                  required
+                  disabled={loading || submitting}
+                />
+                {error ? (
+                  <Text size='sm' c='red'>
+                    {error}
+                  </Text>
+                ) : null}
+                <Button type='submit' loading={submitting} disabled={loading}>
+                  Login
+                </Button>
+                <Button
+                  type='button'
+                  variant='light'
+                  onClick={handleGoogleLogin}
+                  loading={submitting}
+                  disabled={loading}
+                >
+                  Continue with Google
+                </Button>
+              </Stack>
+            </form>
+          )}
+        </Stack>
+      </Paper>
+    </Center>
+  );
+};
+
+export default LoginPage;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next';
 import '@mantine/core/styles.css';
 
 import { ColorSchemeScript, MantineProvider, mantineHtmlProps } from '@mantine/core';
+import { AuthBootstrapper } from '@/features/auth/AuthBootstrapper';
 
 export const metadata: Metadata = {
   title: 'My Mantine app',
@@ -17,6 +18,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <ColorSchemeScript />
       </head>
       <body>
+        <AuthBootstrapper />
         <MantineProvider>{children}</MantineProvider>
       </body>
     </html>

--- a/src/features/auth/AuthBootstrapper.tsx
+++ b/src/features/auth/AuthBootstrapper.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+
+import { useAuth } from '@/hooks/useAuth';
+import { bootstrapAuth, fetchMe } from '@/lib/api/auth';
+
+export const AuthBootstrapper = () => {
+  const { user, loading, logout } = useAuth();
+  const router = useRouter();
+  const lastUidRef = useRef<string | null>(null);
+  const bootstrappedRef = useRef(false);
+  const inFlightRef = useRef(false);
+
+  useEffect(() => {
+    if (loading) {
+      return;
+    }
+
+    if (!user) {
+      lastUidRef.current = null;
+      bootstrappedRef.current = false;
+      inFlightRef.current = false;
+      return;
+    }
+
+    if (inFlightRef.current) {
+      return;
+    }
+
+    if (bootstrappedRef.current && lastUidRef.current === user.uid) {
+      return;
+    }
+
+    inFlightRef.current = true;
+    lastUidRef.current = user.uid;
+
+    const runBootstrap = async () => {
+      try {
+        const token = await user.getIdToken();
+        await bootstrapAuth(token);
+        const me = await fetchMe(token);
+
+        bootstrappedRef.current = true;
+
+        if (me.role === 'friend') {
+          router.replace('/availability');
+          return;
+        }
+
+        if (me.role === 'host') {
+          router.replace('/pre-reservations');
+          return;
+        }
+
+        throw new Error(`Unknown role: ${me.role ?? 'missing'}`);
+      } catch (error) {
+        bootstrappedRef.current = false;
+        await logout();
+      } finally {
+        inFlightRef.current = false;
+      }
+    };
+
+    void runBootstrap();
+  }, [loading, logout, router, user]);
+
+  return null;
+};

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,6 +1,13 @@
 'use client';
 
-import { onAuthStateChanged, signInWithEmailAndPassword, signOut, type User } from 'firebase/auth';
+import {
+  GoogleAuthProvider,
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  signInWithPopup,
+  signOut,
+  type User
+} from 'firebase/auth';
 import { useCallback, useEffect, useState } from 'react';
 
 import { firebaseAuth } from '@/lib/firebase';
@@ -9,6 +16,7 @@ type UseAuthResult = {
   user: User | null;
   loading: boolean;
   login: (email: string, password: string) => Promise<void>;
+  loginWithGoogle: () => Promise<void>;
   logout: () => Promise<void>;
 };
 
@@ -31,9 +39,14 @@ export const useAuth = (): UseAuthResult => {
     await signInWithEmailAndPassword(firebaseAuth, email, password);
   }, []);
 
+  const loginWithGoogle = useCallback(async () => {
+    const provider = new GoogleAuthProvider();
+    await signInWithPopup(firebaseAuth, provider);
+  }, []);
+
   const logout = useCallback(async () => {
     await signOut(firebaseAuth);
   }, []);
 
-  return { user, loading, login, logout };
+  return { user, loading, login, loginWithGoogle, logout };
 };

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,0 +1,10 @@
+import { apiFetch } from './client';
+import type { User } from './types';
+
+export const bootstrapAuth = async (token: string): Promise<User> => {
+  return apiFetch<User>('/auth/bootstrap', { method: 'POST', mode: 'cors' }, token);
+};
+
+export const fetchMe = async (token: string): Promise<User> => {
+  return apiFetch<User>('/me', { method: 'GET', mode: 'cors' }, token);
+};

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,0 +1,43 @@
+const getApiBaseUrl = () => {
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+  if (!baseUrl) {
+    throw new Error('Missing NEXT_PUBLIC_API_BASE_URL');
+  }
+
+  return baseUrl.replace(/\/+$/, '');
+};
+
+const buildHeaders = (token?: string, initHeaders?: HeadersInit) => {
+  const headers = new Headers(initHeaders ?? {});
+
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  return headers;
+};
+
+export const apiFetch = async <T>(path: string, options: RequestInit = {}, token?: string): Promise<T> => {
+  const baseUrl = getApiBaseUrl();
+  const url = `${baseUrl}${path.startsWith('/') ? path : `/${path}`}`;
+
+  const headers = buildHeaders(token, options.headers);
+  if (options.body && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+
+  const response = await fetch(url, {
+    ...options,
+    headers,
+    cache: 'no-store'
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(
+      `API request failed: ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ''}`
+    );
+  }
+
+  return (await response.json()) as T;
+};

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -1,0 +1,7 @@
+export type User = {
+  id?: string;
+  firebase_uid?: string;
+  role?: 'friend' | 'host' | string;
+  name?: string;
+  email?: string;
+};

--- a/src/lib/firebase/app.ts
+++ b/src/lib/firebase/app.ts
@@ -1,27 +1,12 @@
 import { initializeApp, getApp, getApps } from 'firebase/app';
 
-type FirebaseWebConfig = {
-  apiKey: string;
-  authDomain: string;
-  projectId: string;
-  storageBucket?: string;
-  messagingSenderId?: string;
-  appId?: string;
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID
 };
-
-const parseFirebaseConfig = (): FirebaseWebConfig => {
-  const raw = process.env.NEXT_PUBLIC_FIREBASE_CREDENTIAL_JSON;
-  if (!raw) {
-    throw new Error('Missing NEXT_PUBLIC_FIREBASE_CREDENTIAL_JSON');
-  }
-
-  try {
-    return JSON.parse(raw) as FirebaseWebConfig;
-  } catch (error) {
-    throw new Error('Invalid NEXT_PUBLIC_FIREBASE_CREDENTIAL_JSON', { cause: error });
-  }
-};
-
-const firebaseConfig = parseFirebaseConfig();
 
 export const firebaseApp = getApps().length ? getApp() : initializeApp(firebaseConfig);


### PR DESCRIPTION
Firebase ログイン後に /auth/bootstrap API を呼ぶ仕組みを実装してほしい。

【要件】
- Firebase ID Token を取得
- Authorization: Bearer <token> を付与
- bootstrap 成功後に /me API を呼ぶ
- role に応じてリダイレクト
  - friend → /availability
  - host → /pre-reservations

【設計】
- bootstrap は一度だけ
- エラー時はログアウト